### PR TITLE
Use kebab-case in test function names

### DIFF
--- a/t/solving.t
+++ b/t/solving.t
@@ -11,7 +11,7 @@ my $n = Nonogram.new(
     rowspec => ([], [4], [6], [2, 2], [2, 2], [6], [4], [2], [2], [2], []),
 );
 
-lives_ok { $n.solve() }, 'can run .solve';
+lives-ok { $n.solve() }, 'can run .solve';
 
 my $solved = q[
 11111111|


### PR DESCRIPTION
Test function names with underscores have been deprecated in favour of their
kebab-case variants. The deprecated form will be removed in Rakudo 2015.09.
This change brings the test suite up to date with current Rakudo.