### PR TITLE
Fix removed @*INC

### DIFF
--- a/t/solving.t
+++ b/t/solving.t
@@ -2,7 +2,7 @@ use v6;
 use Test;
 plan *;
 
-BEGIN { @*INC.push('lib') }
+use lib 'lib';
 
 use Nonogram;
 

--- a/test.pl
+++ b/test.pl
@@ -1,5 +1,5 @@
 use v6;
-BEGIN { @*INC.push: 'lib' };
+use lib 'lib';
 
 use Nonogram;
 


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.